### PR TITLE
Update public_suffix_list.dat

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10639,6 +10639,11 @@ s3-us-west-2.amazonaws.com
 s3.cn-north-1.amazonaws.com.cn
 s3.eu-central-1.amazonaws.com
 
+// b-tix b-OX: http://b-tix.de http://www.b-OX.de
+// Submitted by Markus Heussen <heussen@b-tix.de> 2016-01-28
+b-ox.de
+b-ox.biz
+
 // BetaInABox
 // Submitted by adrian@betainabox.com 2012-09-13
 betainabox.com


### PR DESCRIPTION
Added b-ox.de and b-ox.biz, both of which are used to access one's personal b-OX (see http://www.b-OX.de) produced by b-tix GmbH (http://b-tix.de).
Each b-OX has its own built in web server.
Each b-OX customer, who are mutually-untrusting parties, has his personal subdomain below b-OX.de or b-OX.biz.
Traffic is routed to the individual b-OX through a b-tix owned server (b-ox.de 87.106.60.157) so each b-OX can be reached from the internet even if behind a NAT router.

Verification:
whois b-ox.biz returns Administrative Contact Email: heussen@b-tix.de.
whois b-ox.de does not show an administrative contact, but mail to webmaster @b-ox.de can be answered for verification.
